### PR TITLE
Run Script for ETL

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,14 +11,11 @@ perform_analysis()
 }
 
 run_etl(){
-#    echo "$1" "$2" "$3" "$4" "$5"
     cd bootstrap
     rm -r temp/
     python run_etl.py "$1" "$2" "$3" "$4" "$5"
     cd ..
 }
-
-#python run_etl.py input_paths/may.warc.paths rufi s3 /Users/rafay/datalab/community-clusters/bootstrap 10
 
 
 if [ "$1" == "etl" ]; then


### PR DESCRIPTION
Added a single runner script from where the whole process can be run as follows and there is no need to go into the bootstrap directory:

**ETL**
```
./run.sh etl input_paths/may.warc.paths rufi s3 /Users/rafay/datalab/community-clusters/bootstrap 10
```

**Plot Communities**
```
./run.sh plot-communities
```

**Graph frame analysis**
```
./run.sh analyze
```

**HTTP Server**
```
./run.sh server
```